### PR TITLE
More changes to get snapshots working

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -47,10 +47,17 @@ android {
     }
 }
 
+//noinspection GroovyAssignabilityCheck
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor 1, 'hours' // refresh changing modules every hour
+}
+
 dependencies {
     compile 'com.android.support:support-annotations:23.1.1'
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.desk:api-client:1.2.1-SNAPSHOT'
+    compile ('com.desk:api-client:1.2.1-SNAPSHOT') {
+        changing = true; // marking as changing since it can be changed frequently
+    }
 
     // instrumentation test dependencies
     androidTestCompile 'com.android.support.test:runner:0.3'

--- a/sdk/src/main/java/com/desk/android/sdk/provider/ArticleProvider.java
+++ b/sdk/src/main/java/com/desk/android/sdk/provider/ArticleProvider.java
@@ -40,9 +40,8 @@ import com.desk.java.apiclient.service.ArticleService;
 import java.util.ArrayList;
 import java.util.List;
 
-import retrofit.Callback;
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 import static com.desk.java.apiclient.model.SortDirection.ASC;
 import static com.desk.java.apiclient.service.ArticleService.FIELD_POSITION;
@@ -145,8 +144,7 @@ public class ArticleProvider {
             this.callbacks = callbacks;
         }
 
-        @Override
-        public void onResponse(Response<ApiResponse<Article>> response, Retrofit retrofit) {
+        @Override public void onResponse(Response<ApiResponse<Article>> response) {
             ApiResponse<Article> apiResponse = response.body();
             if (apiResponse == null) {
                 callbacks.onArticlesLoaded(0, new ArrayList<Article>(), false);

--- a/sdk/src/main/java/com/desk/android/sdk/provider/CaseProvider.java
+++ b/sdk/src/main/java/com/desk/android/sdk/provider/CaseProvider.java
@@ -35,9 +35,8 @@ import com.desk.java.apiclient.model.Message;
 import com.desk.java.apiclient.model.MessageDirection;
 import com.desk.java.apiclient.service.CaseService;
 
-import retrofit.Callback;
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 /**
  * Wraps a {@link CaseService} to provide a higher level of abstraction.
@@ -98,7 +97,7 @@ public class CaseProvider {
                 .enqueue(
                         new Callback<Case>() {
                             @Override
-                            public void onResponse(Response<Case> response, Retrofit retrofit) {
+                            public void onResponse(Response<Case> response) {
                                 callback.onCaseCreated(response.body());
                             }
 

--- a/sdk/src/main/java/com/desk/android/sdk/provider/InboundMailboxProvider.java
+++ b/sdk/src/main/java/com/desk/android/sdk/provider/InboundMailboxProvider.java
@@ -35,9 +35,8 @@ import com.desk.java.apiclient.service.InboundMailboxService;
 
 import java.util.List;
 
-import retrofit.Callback;
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 /**
  * <p>Wraps an {@link InboundMailboxService} to provide a higher level of abstraction.</p>
@@ -97,7 +96,7 @@ public class InboundMailboxProvider {
         }
 
         @Override
-        public void onResponse(Response<ApiResponse<InboundMailbox>> response, Retrofit retrofit) {
+        public void onResponse(Response<ApiResponse<InboundMailbox>> response) {
             ApiResponse<InboundMailbox> apiResponse = response.body();
             callbacks.onInboundMailboxesLoaded(apiResponse.getPage(), apiResponse.getEntriesAsList());
         }

--- a/sdk/src/main/java/com/desk/android/sdk/provider/TopicProvider.java
+++ b/sdk/src/main/java/com/desk/android/sdk/provider/TopicProvider.java
@@ -34,9 +34,8 @@ import com.desk.java.apiclient.service.TopicService;
 
 import java.util.List;
 
-import retrofit.Callback;
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 import static com.desk.java.apiclient.model.SortDirection.ASC;
 import static com.desk.java.apiclient.service.TopicService.FIELD_POSITION;
@@ -100,7 +99,7 @@ public class TopicProvider {
         }
 
         @Override
-        public void onResponse(Response<ApiResponse<Topic>> response, Retrofit retrofit) {
+        public void onResponse(Response<ApiResponse<Topic>> response) {
             callbacks.onTopicsLoaded(response.body().getEntriesAsList());
         }
 

--- a/sdk/src/test/java/com/desk/android/sdk/provider/ArticleProviderTest.java
+++ b/sdk/src/test/java/com/desk/android/sdk/provider/ArticleProviderTest.java
@@ -46,9 +46,9 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import retrofit.Call;
-import retrofit.Callback;
-import retrofit.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 import static com.desk.android.sdk.provider.ArticleProvider.ALL_BRANDS;
 import static com.desk.android.sdk.provider.ArticleProvider.ALL_TOPICS;

--- a/sdk/src/test/java/com/desk/android/sdk/provider/CaseProviderTest.java
+++ b/sdk/src/test/java/com/desk/android/sdk/provider/CaseProviderTest.java
@@ -44,9 +44,9 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
-import retrofit.Call;
-import retrofit.Callback;
-import retrofit.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;

--- a/sdk/src/test/java/com/desk/android/sdk/provider/InboundMailboxProviderTest.java
+++ b/sdk/src/test/java/com/desk/android/sdk/provider/InboundMailboxProviderTest.java
@@ -39,9 +39,9 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import retrofit.Call;
-import retrofit.Callback;
-import retrofit.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 import static com.desk.android.sdk.provider.InboundMailboxProvider.InboundMailboxCallbacks;
 import static com.desk.android.sdk.provider.InboundMailboxProvider.PER_PAGE;

--- a/sdk/src/test/java/com/desk/android/sdk/provider/TopicProviderTest.java
+++ b/sdk/src/test/java/com/desk/android/sdk/provider/TopicProviderTest.java
@@ -40,9 +40,9 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import retrofit.Call;
-import retrofit.Callback;
-import retrofit.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 import static com.desk.android.sdk.provider.TopicProvider.ALL_BRANDS;
 import static com.desk.android.sdk.provider.TopicProvider.TopicCallbacks;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name="desk-android-sdk"
 include ':sdk', ':multi-brand', ':basic'


### PR DESCRIPTION
• Updated to latest api client snapshot dependency
• Set cache expiration of api client snapshot to 1 hour
• Updated retrofit package references
• Changed project name to desk-android-sdk to match conventions in the jfrog oss snapshot repo
